### PR TITLE
Updates to LOC scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ To run for all directories:
 loc *
 ```
 
+To run for a specific year or month:
+```
+loc -y 2020
+loc -y 2020 -m 10
+```
+
 ## Steps
 0. Run `$ ./loc-install.sh` from within this repository to make all scripts executable.
 1. Run `$ loc-setup` from your *locally synced* Dropbox Oral Histories directory.

--- a/getAirtableMetadata.js
+++ b/getAirtableMetadata.js
@@ -7,6 +7,81 @@ var destination = process.argv[3]
 
 var single = process.argv[2];
 
+var fields = [
+  'Identifier',
+  'Title',
+  'Creator',
+  'Description',
+  'Subject: Top level genealogy per language',
+  'Subject: Language Continent of Origin',
+  'Subject: Language Nation of Origin',
+  'Subject: Speaker Genders',
+  'Contributor: Speakers',
+  'Contributor: Caption Authors',
+  'Contributor: Videographer',
+  'Contributor: Description',
+  'Date Created',
+  'Type',
+  'Format',
+  'Language names',
+  'Languages: Speaker preferred names',
+  'Languages: ISO Code (639-3)',
+  'Languages: Glottocode',
+  'Languages: Dialect Glottocode',
+  'Languages: Macrolanguage ISO Code',
+  'Caption Languages',
+  'Caption Languages: ISO Code (639-6)',
+  'Caption Languages: Glottocode',
+  'Caption File Identifier',
+  'Caption File Links',
+  'Coverage: Video Nation',
+  'Coverage: Video Territory',
+  'Coverage: Distribution',
+  'Rights',
+  'Publisher',
+  'Date Received',
+  'Encoded Data',
+  'Tagged Data',
+  'Duration',
+  'Format T',
+  'Format Profile',
+  'Codec ID',
+  'File size',
+  'Format Info',
+  'Format Settings',
+  'Format Settings CABAC',
+  'Format Settings ReFrames',
+  'Codec ID/Info',
+  'Bit rate',
+  'Width',
+  'Height',
+  'Display Aspect Ratio',
+  'Frame Rate',
+  'Standard',
+  'Color Space',
+  'Chroma Subsampling',
+  'Bit Depth',
+  'Scan Type',
+  'Bits (Pixel*Frame)',
+  'Stream size',
+  'Color range',
+  'Color primaries',
+  'Transfer characteristics',
+  'Matrix coefficients',
+  'Codec configuration box',
+  'Format audio',
+  'Format/Info Audio',
+  'Bit Rate Audio',
+  'Bit rate mode audio',
+  'Codec ID Audio',
+  'Channel(s)',
+  'Channel layout',
+  'Compression mode',
+  'Sampling rate',
+  'Stream size audio',
+  'Subjects Reference ID: Ethnologue'
+];
+
 try {
   var base = new Airtable({apiKey: process.env.APIKEY}).base(process.env.BASE);
 
@@ -16,13 +91,14 @@ try {
       timeZone: "America/New_York",
       userLocale: "en-ca",
       filterByFormula: "Identifier='"+single+"'",
+      fields
   }).eachPage(function page(records, fetchNextPage) {
     if (!Array.isArray(records) || !!records.length) {
       records.forEach(function(record) {
           const content = [
             `Metadata for ${record.get('Identifier')}`,
 
-            ...Object.keys(record.fields).map(field => `${field}: ${record.get(field)}`)
+            ...fields.map(field => `${field}: ${record.get(field)}`)
           ].join('\n');
 
           fs.writeFileSync(`${destination}/loctemp__${single}/${record.get('Identifier')}__metadata.txt`, content);

--- a/loc-prepare.sh
+++ b/loc-prepare.sh
@@ -9,13 +9,13 @@ else
   if [[ -f ~/loc-config ]]; then
     source ~/loc-config
     target="${LOC_PreRelease}"
-    # target=`pwd`
 
     for i in "$@"
     do
       echo Copying ${i} to PreRelease: ${target}
 
-      cp -R ${i} "${target}/loctemp__$i"
+      # Copies directory to PreRelease, deleting any existing directory with the same id
+      rsync -a --delete "${i}/" "${target}/loctemp__$i/"
       dot_clean "${target}/loctemp__$i"
       
       echo ${i} is now loctemp__${i}

--- a/loc-prepare.sh
+++ b/loc-prepare.sh
@@ -15,8 +15,9 @@ else
     do
       echo Copying ${i} to PreRelease: ${target}
 
-      # cp -R ${i} "$target/loctemp__$i"
       cp -R ${i} "${target}/loctemp__$i"
+      dot_clean "${target}/loctemp__$i"
+      
       echo ${i} is now loctemp__${i}
       echo "Done. Next, from within ./LOC_PreRelease, run loc-flatten loctemp__${i} to process the directory into the acceptable LOC structure."
     done

--- a/loc-release.sh
+++ b/loc-release.sh
@@ -13,6 +13,13 @@ if [ -z "$1" ]; then
 else
   for i in "$@"
   do
+    # Check directory name
+    if ! [[ $i =~ ^loctemp__[a-zA-Z]+ ]]; then
+      echo "Directory name is not the expected format."
+      echo "Please inspect the directory and make sure all previous steps were run."
+      exit 1
+    fi
+
     id=$(get_id $i)
 
     if ! [ -d $@ ]; then
@@ -70,6 +77,11 @@ else
   # Copy the files
   for i in "$@"; do
     id=$(get_id $i)
+
+    if [ -d "$target/$id" ]; then
+      echo "$id is already staged. Skipping."
+      continue
+    fi
 
     echo "Copying ${id} to ${target}."
     cp -R ${i} "$target/$id"

--- a/loc-store.sh
+++ b/loc-store.sh
@@ -66,6 +66,11 @@ else
   do
     id=$(get_id $i)
 
+    if [ -d "$target/$id" ]; then
+      echo "$id is already released. Skipping."
+      continue
+    fi
+
     echo Moving ${id} to ${target}
     mv ${i} "$target/$id"
   done

--- a/loc.sh
+++ b/loc.sh
@@ -121,11 +121,24 @@ do
     fi
   fi
 
+  if ! [[ -f "loctemp__$i/$i.mp4" ]]; then
+    echo "Skipping $i: Not edited"
+    continue
+  fi
+
+  if ! [[ -f "loctemp__$i/$i.jpg" ]]; then
+    echo "Skipping $i: Thumbnail not found"
+    continue
+  fi
+
   echo "Processing $i"
 
   loc-flatten "loctemp__$i" >> ~/loc-log
 
   find . | grep DS_Store | xargs rm
+
+  # Remove files other than edited video, thumbnail, and metadata
+  rm -r "loctemp__$i/temp"
 
   loc-bag "loctemp__$i" >> ~/loc-log 2>&1
 

--- a/loc.sh
+++ b/loc.sh
@@ -13,67 +13,124 @@ get_distribution () {
 
 if [ -z "$1" ]; then
   printf "Usage: $ loc <directory name>\nPlease make sure you reference a desired oral history directory to prepare.\n"
-else
-  if [[ -f ~/loc-config ]]; then
-    source ~/loc-config
-
-    if [[ $LOC_Mode = "dev" ]]; then
-      echo "Running in dev mode. Will not check metadata."
-    else
-      echo "Running in production mode."
-    fi
-
-    > ~/loc-log
-
-    echo "Preparing..."
-
-    loc-prepare $@ >> ~/loc-log
-
-    cd $LOC_PreRelease
-
-    if [[ ! $LOC_Mode = "dev" ]]; then
-      echo "Updating metadata..."
-      for i in $@
-      do
-        APIKEY=$LOC_APIKEY BASE=$LOC_BASE loc-metadata-retriever $i ./ ./ >> ~/loc-log 2>&1
-        metadata_status=$?
-        if [[ $metadata_status -eq 1 ]]; then
-          echo "Encountered error updating metadata for $i. Check ~/loc-log."
-          echo "If you are using local directories for testing, set LOC_Mode='dev' in ~/loc-config."
-          exit 1
-        fi
-      done
-    else
-      for i in $@
-      do
-        touch "./loctemp__${i}/${i}__metadata.txt"
-      done
-    fi
-
-    for i in $@
-    do
-      if [[ ! $LOC_Mode = "dev" ]]; then
-        if [[ $(get_distribution $i) = "Wikitongues only" ]]; then
-          echo "Skipping $i: Not for external distribution"
-          continue
-        fi
-      fi
-
-      echo "Processing $i"
-
-      loc-flatten "loctemp__$i" >> ~/loc-log
-
-      find . | grep DS_Store | xargs rm
-
-      loc-bag "loctemp__$i" >> ~/loc-log 2>&1
-
-      loc-release "loctemp__$i" >> ~/loc-log 2>&1
-      
-    done
-
-    echo "Done!"
-
-  else
-    echo "Couldn't find loc-config. Please run loc-setup."
-  fi
+  exit 1
 fi
+
+if ! [[ -f ~/loc-config ]]; then
+  echo "Couldn't find loc-config. Please run loc-setup."
+  exit 1
+fi
+
+directories=()
+
+month=''
+year=''
+while getopts 'm:y:' flag; do
+  case "${flag}" in
+    m) month="${OPTARG}" ;;
+    y) year="${OPTARG}" ;;
+    *) echo "Invalid flag ${flag}"
+       exit 1 ;;
+  esac
+done
+
+if ! [ -z $year ]; then
+  # Year flag provided
+  if ! [[ $year =~ ^[0-9]{4}$ ]]; then
+    echo "Invalid year $year"
+    exit 1
+  fi
+
+  if ! [ -z $month ]; then
+    # Month flag provided
+    if ! [[ $month =~ ^0[1-9]|1[0-2]$ ]]; then
+      echo "Invalid month $month"
+      echo "Must be 01-12"
+      exit 1
+    fi
+  else
+    month='(0[1-9]|1[0-2])'
+  fi
+
+  directories=$(ls | egrep -e "[a-zA-Z]+_${year}${month}[0-9]{2}_[a-z]+(\+[a-z]+)*$")
+
+elif ! [ -z $month ]; then
+  echo "Must set year, e.g. $ loc -m 10 -y 2020"
+  exit 1
+else
+  directories=$@
+fi
+
+echo "Will process the following directories:"
+n=0
+for i in $directories
+do
+  echo "* $i"
+  n=$((n+1))
+done
+echo "$n total"
+read -r -p "Proceed? [y/N] " confirmation
+if ! [[ $confirmation =~ ^([yY][eE][sS])|[yY]$ ]]; then
+  echo "Exiting."
+  exit 0
+fi
+
+source ~/loc-config
+
+if [[ $LOC_Mode = "dev" ]]; then
+  echo "Running in dev mode. Will not check metadata."
+else
+  echo "Running in production mode."
+fi
+
+> ~/loc-log
+
+for i in $directories
+do
+  echo "Preparing $i"
+  loc-prepare $i >> ~/loc-log
+done
+
+cd $LOC_PreRelease
+
+if [[ ! $LOC_Mode = "dev" ]]; then
+  for i in $directories
+  do
+    echo "Updating metadata for $i"
+    APIKEY=$LOC_APIKEY BASE=$LOC_BASE loc-metadata-retriever $i ./ ./ >> ~/loc-log 2>&1
+    metadata_status=$?
+    if [[ $metadata_status -eq 1 ]]; then
+      echo "Encountered error updating metadata for $i. Check ~/loc-log."
+      echo "If you are using local directories for testing, set LOC_Mode='dev' in ~/loc-config."
+      exit 1
+    fi
+  done
+else
+  for i in $directories
+  do
+    touch "./loctemp__${i}/${i}__metadata.txt"
+  done
+fi
+
+for i in $directories
+do
+  if [[ ! $LOC_Mode = "dev" ]]; then
+    if [[ $(get_distribution $i) = "Wikitongues only" ]]; then
+      echo "Skipping $i: Not for external distribution"
+      continue
+    fi
+  fi
+
+  echo "Processing $i"
+
+  loc-flatten "loctemp__$i" >> ~/loc-log
+
+  find . | grep DS_Store | xargs rm
+
+  loc-bag "loctemp__$i" >> ~/loc-log 2>&1
+
+  loc-release "loctemp__$i" >> ~/loc-log 2>&1
+  
+done
+
+echo "Done!"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,123 @@
+{
+  "name": "loc-metadata-retriever",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "loc-metadata-retriever",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "airtable": "^0.10.0"
+      },
+      "bin": {
+        "loc-metadata-retriever": "getAirtableMetadata.js"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "14.14.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.2.tgz",
+      "integrity": "sha512-jeYJU2kl7hL9U5xuI/BhKPZ4vqGM/OmK6whiFAXVhlstzZhVamWhDSmHyGLIp+RVyuF9/d0dqr2P85aFj4BvJg=="
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/abortcontroller-polyfill": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.5.0.tgz",
+      "integrity": "sha512-O6Xk757Jb4o0LMzMOMdWvxpHWrQzruYBaUruFaIOfAQRnWFxfdXYobw12jrVHGtoXk6WiiyYzc0QWN9aL62HQA=="
+    },
+    "node_modules/airtable": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/airtable/-/airtable-0.10.0.tgz",
+      "integrity": "sha512-6gBUG+z1kqvwyHYWlc+y74TfYpc18mvmNuVcefjlvd6MSgLP9Hk47ByyBS6Ke8zdSk6kBTDpdiwCjoJQUpu6yg==",
+      "dependencies": {
+        "@types/node": "^14.0.14",
+        "abort-controller": "^3.0.0",
+        "abortcontroller-polyfill": "^1.4.0",
+        "lodash": "4.17.19",
+        "node-fetch": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    }
+  },
+  "dependencies": {
+    "@types/node": {
+      "version": "14.14.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.2.tgz",
+      "integrity": "sha512-jeYJU2kl7hL9U5xuI/BhKPZ4vqGM/OmK6whiFAXVhlstzZhVamWhDSmHyGLIp+RVyuF9/d0dqr2P85aFj4BvJg=="
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
+    "abortcontroller-polyfill": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.5.0.tgz",
+      "integrity": "sha512-O6Xk757Jb4o0LMzMOMdWvxpHWrQzruYBaUruFaIOfAQRnWFxfdXYobw12jrVHGtoXk6WiiyYzc0QWN9aL62HQA=="
+    },
+    "airtable": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/airtable/-/airtable-0.10.0.tgz",
+      "integrity": "sha512-6gBUG+z1kqvwyHYWlc+y74TfYpc18mvmNuVcefjlvd6MSgLP9Hk47ByyBS6Ke8zdSk6kBTDpdiwCjoJQUpu6yg==",
+      "requires": {
+        "@types/node": "^14.0.14",
+        "abort-controller": "^3.0.0",
+        "abortcontroller-polyfill": "^1.4.0",
+        "lodash": "4.17.19",
+        "node-fetch": "^2.6.0"
+      }
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
+    "lodash": {
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,10 +7,6 @@
     "loc-metadata-retriever": "getAirtableMetadata.js"
   },
   "preferGlobal": true,
-  "dependencies": {
-    "airtable": "^0.7.0"
-  },
-  "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -23,5 +19,8 @@
   "bugs": {
     "url": "https://github.com/wikitongues/Library-of-Congress/issues"
   },
-  "homepage": "https://github.com/wikitongues/Library-of-Congress"
+  "homepage": "https://github.com/wikitongues/Library-of-Congress",
+  "dependencies": {
+    "airtable": "^0.10.0"
+  }
 }


### PR DESCRIPTION
- Run a batch for a specific year or month: `loc -y 2020 -m 10`
- loc-prepare prevents erroneous directory structure if called for a directory that already exists in PreRelease
- loc-release prevents staging of directory that is already staged
- loc-store prevents storing of directory already in production
- Call dot_clean to cleanup troublesome hidden files created by MacOS on external drives
- Include only the desired metadata fields
- Updated Airtable.js, now supports id's with diacritics